### PR TITLE
Add more docs, example from readme to rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,61 @@
+//! Add `inspect` to all futures for easy debugging.
+//!
+//! This module provides a way to wrap `Future`s in another `Future` that logs
+//! internal calls to poll. This allows a better understanding for when polls
+//! happen for both teaching and debugging.
+//!
+//! This uses the `log` crate internally, so you need to have a logger set up
+//! to see any output (e.g., by using the `env_logger` crate).
+//!
+//! To get access to the `inspect` methid, import the crate and load the
+//! extension trait into scope with `use futures_poll_log::LoggingExt`.
+//!
+//! # Examples
+//!
+//! ```rust
+//! extern crate futures;
+//! extern crate futures_poll_log;
+//!
+//! use futures::{Future, future};
+//! use futures_poll_log::LoggingExt;
+//!
+//! # fn main() {
+//! let result: Result<i32, _> =
+//!     future::ok(3)
+//!     .inspect("immeditate future")
+//!     .map(|i| i * 2)
+//!     .inspect("mapped future")
+//!     .and_then(|_| Err("ooops".to_string()))
+//!     .inspect("failing future")
+//!     .wait();
+//! # }
+//! ```
+//!
+//! This will log:
+//!
+//! ```plain
+//! DEBUG - Polling future `failing future'
+//! DEBUG - Polling future `mapped future'
+//! DEBUG - Polling future `immeditate future'
+//! DEBUG - Future `immeditate future' polled: Ok(Ready(3))
+//! DEBUG - Future `mapped future' polled: Ok(Ready(6))
+//! DEBUG - Future `failing future' polled: Err("ooops")
+//! ```
+//!
+//! Note that it logs the Async state.
+//!
+//! # Notes on logging
+//!
+//! The log target is `futures_log`.
+//!
+//! Building the crate with the feature "silence" makes the effect completely
+//! vanish, _including_ the intermediate futures. The library also stops binding
+//! to `log` lib.
+//!
+//! This allows you to keep the tagging around for future debugging sessions.
+
 #![deny(missing_docs)]
 
-//! This module provides a way to wrap Futures
-//! in another Future that logs internal calls
-//! to poll. This allows a better understanding
-//! for when polls happen for both teaching
-//! and debugging.
 extern crate futures;
 
 #[cfg(not(feature="silence"))]


### PR DESCRIPTION
Just saw the crate (from your tweet) and noticed that the API docs could use an example. I didn't invent my own, this is the same as in the Readme, so this also checks that the example code compiles.

(Alternatively/additionally, run `rustdoc --test Readme.md` on Travis.)