### PR TITLE
Adding possibility to simple inspect future polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "futures-poll-log"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "futures 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ extern crate futures;
 #[cfg(not(feature="silence"))]
 #[macro_use]
 extern crate log;
-
+use  futures::Async;
 use futures::{Future, Poll};
 use std::fmt::Debug;
 
@@ -90,7 +90,12 @@ impl<T, E, F> Future for LoggedFuture<T, E, F>
         if self.log_content{
             debug!(target: "futures_log", "Future `{}' polled: {:?}", self.label, poll);
         }else{
-            debug!(target: "futures_log", "Future `{}' polled", self.label);
+            match &poll{
+                &Ok(Async::Ready(_))=>{ debug!(target: "futures_log", "Future `{}' polled and is ready", self.label);},
+                &Ok(Async::NotReady)=>{ debug!(target: "futures_log", "Future `{}' polled and is not ready", self.label);},
+                &Err(ref e)=>{ debug!(target: "futures_log", "Future `{}' polled and  errored {:?}", self.label,e);},
+            }
+           
         }
         poll
     }


### PR DESCRIPTION
I have added simple inspection future that only logs status and error instead of the whole content of future. 